### PR TITLE
Adding support for 'as' keyword

### DIFF
--- a/syntax/wren.vim
+++ b/syntax/wren.vim
@@ -12,7 +12,7 @@ syntax region wrenString contains=wrenEscape start=/\v"/ skip=/\v\\"/ end=/\v"/
 
 syntax keyword wrenConditional else if
 syntax keyword wrenRepeat break for while continue
-syntax keyword wrenKeyword class in is new return super this var import
+syntax keyword wrenKeyword class as in is new return super this var import
 syntax keyword wrenConstruct construct contained containedin=wrenConstructor
 syntax keyword wrenStatic static contained containedin=wrenMethod,wrenForeignMethod
 syntax keyword wrenForeign foreign contained containedin=wrenForeignMethod


### PR DESCRIPTION
Wren 0.4.0 officially added the `import 'moduleName' for Variable as AliasedVariable` form of syntax.

This PR just adds `as` as an additional keyword to the list. 